### PR TITLE
Update compose.yaml to use test password directly

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -33,7 +33,7 @@ services:
           '3306',
           '-u',
           'root',
-          '-p$picco123$'
+          '-ppicco123$'
         ]
       timeout: 20s
       retries: 15


### PR DESCRIPTION
Currently, running `sudo docker compose up` errors because it is referring to an environment variable which is not set.  Here, we remove the environment variable to use the DB test password directly, so that `sudo docker compose up` works directly without additional configuration.

Previous output:
```
$ sudo docker compose up
WARN[0000] The "picco123" variable is not set. Defaulting to a blank string. 
[+] Running 0/3
 ⠙ mysql Pulling                                                                                                                                         0.2s 
 ⠙ web-ui Pulling                                                                                                                                        0.2s 
[+] Running 0/3e-api Pulling                                                                                                                             0.2s 
 ⠹ mysql Pulling                                                                                                                                         0.3s 
 ⠹ web-ui Pulling                                                                                                                                        0.3s 
 ⠹ spurtcommerce-api Pulling                                                                                                                             0.3s 
error getting credentials - err: exit status 1, out: ``
```
